### PR TITLE
Enable run of ansible-test

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,9 +13,46 @@ on:
     - cron: 1 0 * * *  # Run daily at 0:01 UTC
 
 jobs:
-  build:
+  make:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: sanity
+          # - name: units
+          # - name: integration
+          # - name: coverage
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run workarounds github-action specific
+        # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
+        run: |
+          sudo apt-get -qq -y remove --purge ansible
+          mkdir -p ~/.local/bin
+          export PATH=$HOME/.local/bin:$PATH
+          # remove ansible 2.9 which comes free on github actions
+          # assure we have a pip with decent resolver
+          python3 -m pip install "pip>=20.3.1"
+          # lets fix some already missing dependencies from gha ubuntu image
+          pip3 install launchpadlib pygobject
+          # lets see the goodies...
+          pip3 check
+          # to bring pip installed stuff in user PATH, for *subsequent* runs
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Run make devenv
+        run: |
+          echo "PATH=$PATH"
+          make devenv
+      - name: Run make install
+        run: |
+          make install
+          make ${{ matrix.name }}
+
+  tox:
     name: ${{ matrix.tox_env }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -64,7 +101,8 @@ jobs:
   publish:
     name: Publish to PyPI registry
     needs:
-      - build
+      - tox
+      - make
     runs-on: ubuntu-latest
 
     env:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,87 @@
+DESTDIR ?=
+PYTHON ?= $(shell command -v python3 python|head -n1)
+PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
+
+.EXPORT_ALL_VARIABLES:
+
+ANSIBLE_COLLECTIONS_PATH = $(HOME)/.ansible/collections/ansible_collections
+ANSIBLE_TEST = cd $(ANSIBLE_COLLECTIONS_PATH)/pycontribs/protogen && ansible-test
+ANSIBLE := $(shell command -v ansible)
+
+.PHONY: test sanity units env integration shell coverage network-integration windows-integration lint default help build install devenv
+
+HAS_ANSIBLE := $(shell command -v ansible 2> /dev/null)
+
+default: help
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+print("Usage: make <target>")
+cmds = {}
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+	  target, help = match.groups()
+	  cmds.update({target: help})
+for cmd in sorted(cmds):
+		print(" * '%s' - %s" % (cmd, cmds[cmd]))
+endef
+export PRINT_HELP_PYSCRIPT
+
+help:
+	@$(PYTHON) -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+devenv:	 # Assures we have all pre-requisites for testing
+ifndef HAS_ANSIBLE
+	python3 -m pip install --user "ansible-base>=2.10"
+endif
+	$(ANSIBLE) --version
+
+build: devenv  ## Builds collection
+	sh -c "rm -rf dist/* .cache/collections/* || true"
+	@echo build collection
+	ansible-galaxy collection build -v -f --output-path dist/
+
+install: build  ## Installs collection
+	@echo install collection to $(ANSIBLE_COLLECTIONS_PATH)
+	ansible-galaxy collection install -f dist/*.tar.gz -p $(ANSIBLE_COLLECTIONS_PATH)
+	@echo validates that collection is reported as installed
+	ansible-galaxy collection list | grep 'pycontribs.protogen'
+
+test:  ## Runs ansible-test
+	$(ANSIBLE_TEST) ansible-test --help
+
+# BEGIN ansible-test commands
+sanity: install  ## Runs ansible-test sanity
+	$(ANSIBLE_TEST) sanity --requirements
+
+units:  ## Runs ansible-test units [NOT-IMPLEMENTED]
+	$(ANSIBLE_TEST) units --requirements
+
+integration:  ## posix integration tests [NOT-IMPLEMENTED]
+	$(ANSIBLE_TEST) integration --requirements
+
+network-integration:  ## network integration tests [NOT-IMPLEMENTED]
+	$(ANSIBLE_TEST) network-integration --requirements
+
+windows-integration:  ## windows integration tests [NOT-IMPLEMENTED]
+	$(ANSIBLE_TEST) windows-integration --requirements
+
+shell:  ## open an interactive shell
+	$(ANSIBLE_TEST) shell
+
+coverage:  ## code coverage management and reporting [NOT-IMPLEMENTED]
+	$(ANSIBLE_TEST) coverage --requirements
+
+env:  ##  show information about the test environment
+	$(ANSIBLE_TEST) env
+# END of ansible-test commands
+
+# BEGIN tox commands
+lint:  ## Lints the code
+	tox -e linters
+
+molecule:  ## Runs molecule 'default' scenario
+	tox -e molecule
+# END of tox commands

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,10 @@ setenv =
 skip_install = True
 allowlist_externals =
     sh
+    make
+commands =
+    echo {posargs}
+
 
 [testenv:lint]
 description = Runs all linting tasks
@@ -82,3 +86,8 @@ commands =
     # https://github.com/ansible-community/molecule/pull/2998
     {[testenv:packaging]commands}
     molecule test -s default
+
+[testenv:make]
+description = Runs make from inside venv.
+commands =
+    make {posargs}


### PR DESCRIPTION
- include helper Makefile
- enable sanity check run on CI
- keep other commands disabled until we implement them

When `make` is called without arguments it prints available options:
```
$ make                                                                                                                          [14:56:30]
Usage: make <target>
 * 'build' - Builds collection
 * 'coverage' - code coverage management and reporting [NOT-IMPLEMENTED]
 * 'env' -  show information about the test environment
 * 'install' - Installs collection
 * 'integration' - posix integration tests [NOT-IMPLEMENTED]
 * 'lint' - Lints the code
 * 'molecule' - Runs molecule 'default' scenario
 * 'network-integration' - network integration tests [NOT-IMPLEMENTED]
 * 'sanity' - Runs ansible-test sanity
 * 'shell' - open an interactive shell
 * 'test' - Runs ansible-test
 * 'units' - Runs ansible-test units [NOT-IMPLEMENTED]
 * 'windows-integration' - windows integration tests [NOT-IMPLEMENTED]
```