### PR TITLE
Enable ansible-test units

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - name: sanity
-          # - name: units
+          - name: units
           # - name: integration
           # - name: coverage
     steps:

--- a/tests/unit/test_example.py
+++ b/tests/unit/test_example.py
@@ -1,0 +1,7 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def test_one():
+    """That is a test that not really do anything."""
+    pass


### PR DESCRIPTION
- adds and empty test
- enables gha job for it
- allows user to run "make units" to run them for current python