### PR TITLE
Enable ansible-test coverage

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,7 +23,7 @@ jobs:
           - name: sanity
           - name: units
           # - name: integration
-          # - name: coverage
+          - name: coverage
     steps:
       - uses: actions/checkout@v1
       - name: Run workarounds github-action specific

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,10 @@ windows-integration: install  ## windows integration tests [NOT-IMPLEMENTED]
 shell:  ## open an interactive shell
 	$(ANSIBLE_TEST) shell
 
-coverage:  ## code coverage management and reporting [NOT-IMPLEMENTED]
-	$(ANSIBLE_TEST) coverage --requirements
+coverage: units ## code coverage management and reporting
+	$(ANSIBLE_TEST) units --requirements --python $(PYTHON_VERSION) --coverage
+	$(ANSIBLE_TEST) coverage combine
+	$(ANSIBLE_TEST) coverage report
 
 env:  ##  show information about the test environment
 	$(ANSIBLE_TEST) env


### PR DESCRIPTION
- enables gha job for coverage
- allows user to run "make coverage" to run them for current python