### PR TITLE
Add one minimal integration test

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - name: sanity
           - name: units
-          # - name: integration
+          - name: integration
           - name: coverage
     steps:
       - uses: actions/checkout@v1

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ sanity: install  ## Runs ansible-test sanity
 units: install  ## Runs ansible-test units
 	$(ANSIBLE_TEST) units --requirements --python $(PYTHON_VERSION)
 
-integration: install  ## posix integration tests [NOT-IMPLEMENTED]
-	$(ANSIBLE_TEST) integration --requirements
+integration: install  ## posix integration tests
+	$(ANSIBLE_TEST) integration --requirements --python $(PYTHON_VERSION)
 
 network-integration: install  ## network integration tests [NOT-IMPLEMENTED]
 	$(ANSIBLE_TEST) network-integration --requirements
@@ -79,6 +79,7 @@ shell:  ## open an interactive shell
 
 coverage: units ## code coverage management and reporting
 	$(ANSIBLE_TEST) units --requirements --python $(PYTHON_VERSION) --coverage
+	$(ANSIBLE_TEST) integration --requirements --python $(PYTHON_VERSION) --coverage
 	$(ANSIBLE_TEST) coverage combine
 	$(ANSIBLE_TEST) coverage report
 

--- a/tests/integration/targets/foo/runme.sh
+++ b/tests/integration/targets/foo/runme.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo 123


### PR DESCRIPTION
- enables gha job for coverage
- allows user to run "make coverage" to run them for current python