### PR TITLE
set requirement tox < 4.0.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     linters
     yolo
 requires =
+    tox < 4.0.0
     tox-ansible >= 1.0.0a0
 
 skipsdist = True


### PR DESCRIPTION
tox version 4 was released in December. As tox-ansible is not compatible with this, tox < 4.0.,0 must set as hard requirement.

really nice project, was trying it our yesterday, but had problems to get it to work because of this. 
